### PR TITLE
distinguish the layeradd event

### DIFF
--- a/dist/visiomatic-src.js
+++ b/dist/visiomatic-src.js
@@ -955,6 +955,7 @@ L.TileLayer.IIP = L.TileLayer.extend({
 	},
 
 	initialize: function (url, options) {
+		this.type = 'tilelayer';
 		this._url = url.replace(/\&.*$/g, '');
 
 		options = L.setOptions(this, options);

--- a/src/TileLayer.IIP.js
+++ b/src/TileLayer.IIP.js
@@ -71,7 +71,7 @@ L.TileLayer.IIP = L.TileLayer.extend({
 	},
 
 	initialize: function (url, options) {
-
+		this.type = 'tilelayer';
 		this._url = url.replace(/\&.*$/g, '');
 
 		options = L.setOptions(this, options);


### PR DESCRIPTION
Added a property that lets you distinguish the layeradd event from TileLayer from the other classes.