### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -388,7 +388,7 @@ class ADSArxivStyle(UnsrtStyle):
                 optional_field('adsurl'),
                 join ['http://arxiv.org/abs/', optional_field('eprint')],
                 optional_field('url'),
-                optional [join ['http://dx.doi.org/', field('doi')]]
+                optional [join ['https://doi.org/', field('doi')]]
         ]
         template = toplevel [
             self.format_names('author'),
@@ -408,7 +408,7 @@ class ADSArxivStyle(UnsrtStyle):
                 optional_field('adsurl'),
                 optional [join ['http://arxiv.org/abs/', field('eprint')]],
                 optional_field('url'),
-                optional [join ['http://dx.doi.org/', field('doi')]]
+                optional [join ['https://doi.org/', field('doi')]]
         ]
         template = toplevel [
             sentence [self.format_names('author')],


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). It may be a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to the code that generates new DOI links.

Cheers!